### PR TITLE
Added sample default parameter to forward method

### DIFF
--- a/layers/BBB_MCMF_LRT/BBBConv.py
+++ b/layers/BBB_MCMF_LRT/BBBConv.py
@@ -50,7 +50,7 @@ class BBBConv2d(ModuleWrapper):
             self.bias_mu.data.normal_(0, 0.1)
             self.bias_rho.data.normal_(-3, 0.1)
 
-    def forward(self, x):
+    def forward(self, x, sample=True):
 
         self.W_sigma = torch.log1p(torch.exp(self.W_rho))
         if self.use_bias:


### PR DESCRIPTION
BBB_MCMF_LRT/BBBconv.py layer did not have the 'sample' variable defined in the forward method, and so would crash when called. The sample variable has been added as a default parameter to the forward method, matching expected behaviour of the other layers.